### PR TITLE
Add PAT for bypassing branch protection for autocommit

### DIFF
--- a/.github/workflows/autocommit.yaml
+++ b/.github/workflows/autocommit.yaml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: main
+          token: ${{ secrets.GH_PAT }}
 
       - name: Update publish version
         id: update


### PR DESCRIPTION
Add a PAT to the GitHub workflow to bypass branch protection.